### PR TITLE
Updated .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+bin/
+chat_server_log.log
+.project


### PR DESCRIPTION
If you have an Eclipse project, this will prevent `.project` from being staged to the repo. Moreover, the `bin` folder created from a proper `python build.py build` will not be staged either.